### PR TITLE
Fix MQTT discovery message size

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Fetch the unit state with the status command and set the state with a JSON paylo
 ## Home Assistant
 
 The firmware announces itself via MQTT discovery so it will appear automatically as a climate entity when the MQTT integration is enabled. Configure the broker settings in `config-private.h`.
-Discovery uses the full MQTT property names as expected by recent Home Assistant releases (2025.7+).
+Discovery uses the full MQTT property names as expected by recent Home Assistant releases (2025.7+). The discovery JSON is quite large so set `MQTT_MAX_PACKET_SIZE` to at least `1152` in `platformio.ini`.
 
 Each attribute is published under `<BASE_TOPIC>/<item>`. With the default `BASE_TOPIC` of `mhi-ac-rc-ex3-1` the following topics are used:
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@ lib_deps =
     ArduinoJson@5.13.4
     NTPClient@3.1.0
     PubSubClient@2.7
-build_flags = -DMQTT_MAX_PACKET_SIZE=256
+build_flags = -DMQTT_MAX_PACKET_SIZE=1152
 
 
 [env:d1_mini]


### PR DESCRIPTION
## Summary
- bump MQTT packet size limit to 1152 bytes
- mention the packet size requirement in README

## Testing
- `pio run` *(fails: config-private.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c7c9136b4832b9a1af532c58a12d2