### PR TITLE
Add fan mode support to MQTT discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,6 @@ Each attribute is published under `<BASE_TOPIC>/<item>`. With the default `BASE_
 - `mhi-ac-rc-ex3-1/mode/state`
 - `mhi-ac-rc-ex3-1/temp/state`
 - `mhi-ac-rc-ex3-1/speed/state`
+- `mhi-ac-rc-ex3-1/fan_mode/state`
 
 Updates from the wall controller are pushed over MQTT so Home Assistant always reflects the latest state.


### PR DESCRIPTION
## Summary
- support `fan_mode` in MQTT discovery
- handle `fan_mode` in MQTT commands
- publish fan mode state
- document new `fan_mode` topic

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cb499d680832bbbb3c3a0f7e7c426